### PR TITLE
Support for H6 headers in PDF; H4 and H5 titles are in separate lines

### DIFF
--- a/doc_build/doc_builder.py
+++ b/doc_build/doc_builder.py
@@ -113,6 +113,8 @@ class DocBuilder:
             "-F",
             self.get_filter("convert_mathblocks"),
             "-F",
+            self.get_filter("header6"),
+            "-F",
             self.get_filter("resolve_sections"),
             "-F",
             self.get_filter("sections_new_page"),

--- a/doc_build/filters/filter_header6.py
+++ b/doc_build/filters/filter_header6.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+from pandocfilters import toJSONFilter, RawBlock, stringify
+
+
+def header_to_subsubparagraph(key, value, format, meta):
+    if key == 'Header':
+        level, attr, contents = value
+        if level == 6:
+            text = stringify(contents)
+            return RawBlock('latex', f'\\subsubparagraph{{{text}}}')
+
+
+if __name__ == "__main__":
+    toJSONFilter(header_to_subsubparagraph)

--- a/doc_build/template/after-header-includes.latex
+++ b/doc_build/template/after-header-includes.latex
@@ -41,9 +41,64 @@ $endif$
 % \rowcolors{2}{gray!10}{white}
 \usepackage{booktabs}
 
+% Preamble additions for subsubparagraph
+\usepackage{titlesec}
+
+% H4 and H5 are now blocks
+\titleformat{\paragraph}[block]
+  {\normalfont\normalsize\bfseries}
+  {\theparagraph}
+  {1em}
+  {}
+
+\titlespacing*{\paragraph}
+  {0pt}
+  {2.5ex plus .2ex minus .2ex}
+  {0.5em}
+
+\titleformat{\subparagraph}[block]
+  {\normalfont\normalsize\bfseries}
+  {\thesubparagraph}
+  {1em}
+  {}
+
+\titlespacing*{\subparagraph}
+  {0pt}
+  {2.5ex plus .2ex minus .2ex}
+  {0.5em}
+
+% Define subsubparagraph as a new sectioning command, a subdivision of subparagraph
+\titleclass{\subsubparagraph}{straight}[\subparagraph]
+
+% Create a counter for subsubparagraph that resets with each new subparagraph
+\newcounter{subsubparagraph}[subparagraph]
+
+% Define how the subsubparagraph number should be formatted
+\renewcommand\thesubsubparagraph{\thesubparagraph.\arabic{subsubparagraph}}
+
+% Format
+\titleformat{\subsubparagraph}
+  {\normalfont\normalsize\bfseries} % Font style: normal font, normal size, bold
+  {\thesubsubparagraph}             % THIS IS THE LABEL/NUMBERING PART
+  {1em}                             % Horizontal space between label and title
+  {}                                % Code to be executed after the title (empty in this case)
+
+% Spacing
+\titlespacing*{\subsubparagraph}
+  {0pt}                             % Left indentation
+  {2.5ex plus .2ex minus .2ex}      % Vertical space before the title
+  {0.5em}                           % Vertical space after the title (or horizontal for run-in)
+
+% Fix the potential TOC issue
+\makeatletter
+\newcommand{\l@subsubparagraph}{\@dottedtocline{6}{7em}{4em}}
+\makeatother
+
+\setcounter{secnumdepth}{6}
+\setcounter{tocdepth}{6}
+
 % adjust the title page style
 \usepackage{fontspec}
-\usepackage{sectsty}
 \usepackage{titling}
 
 \newfontfamily\titlefont[Path=$fontpath$, Extension=.ttf, UprightFont=*]{Montserrat-Regular}

--- a/doc_build/template/default.latex
+++ b/doc_build/template/default.latex
@@ -41,8 +41,8 @@ $endif$
 \lstset{basicstyle=\ttfamily}
 \newcommand{\CodeEmphasis}[1]{\textcolor{black}{\textbf{#1}}}
 \newcommand{\CodeEmphasisLine}[1]{\textcolor{black}{\textbf{#1}}}
-\let\originAlParaGraph\paragraph
-\renewcommand{\paragraph}[1]{\originAlParaGraph{#1} \hfill}
+% \let\originAlParaGraph\paragraph
+% \renewcommand{\paragraph}[1]{\originAlParaGraph{#1} \hfill}
 $after-header-includes.latex()$
 $hypersetup.latex()$
 

--- a/tests/specification/headers_levels.md
+++ b/tests/specification/headers_levels.md
@@ -1,0 +1,31 @@
+# Heading Level 1
+
+Some introduction text under level 1.
+
+## Heading Level 2
+
+Content under level 2 heading.
+
+### Heading Level 3
+
+Some text under level 3.
+
+#### Heading Level 4
+
+Additional notes under level 4.
+
+##### Heading Level 5
+
+This is a level 5 heading. It usually maps to `\paragraph` in LaTeX.
+
+###### Heading Level 6
+
+This is a level 6 heading. It often maps to `\subparagraph` or needs customization in LaTeX.
+
+##### Heading Level 5
+
+This is a level 5 heading. It usually maps to `\paragraph` in LaTeX.
+
+###### Heading Level 6
+
+This is a level 6 heading. It often maps to `\subparagraph` or needs customization in LaTeX.


### PR DESCRIPTION
[aousd_core_spec.pdf](https://github.com/user-attachments/files/21404144/aousd_core_spec.pdf)
