### PR TITLE
diff: more outputs, better organized

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -42,4 +42,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: aousd_doc_build-diff
-          path: tests/build/diff_test-*
+          path: |
+            tests/build/diff*/aousd_doc_build*
+            tests/build/diff*/images/**

--- a/README.md
+++ b/README.md
@@ -113,7 +113,9 @@ When `--diff from_ref [to_ref]` is used, the builder does not build from the cur
 3. Converts each combined markdown to a Pandoc JSON AST, diffs the two ASTs to produce an annotated diff (added/removed blocks), and converts the diff AST back to markdown.
 4. Runs the normal Pandoc pipeline (filters, PDF/HTML/DOCX) on that combined diff markdown.
 
-Outputs are written under the normal build output directory with base name `diff_<short_from>_<short_to>` so they do not overwrite a regular build.
+Outputs are written under the normal build output directory with names like
+`<base>.before_<from>.<ext>`, `<base>.after_<to>.<ext>`, and
+`<base>.diff_<from>_to_<to>.<ext>`, so they do not overwrite a regular build.
 
 ## Development
 

--- a/doc_build/doc_builder.py
+++ b/doc_build/doc_builder.py
@@ -29,7 +29,12 @@ if sys.version_info < (3, 10):
 MARKDOWN_OUTPUT_FORMAT = "gfm"
 
 MARKDOWN_FORMAT = "markdown-hard_line_breaks"
-COMBINED_SPEC_FILENAME = "combined_spec.md"
+COMBINED_SPEC_BASENAME = "combined_spec"
+COMBINED_SPEC_FILENAME = f"{COMBINED_SPEC_BASENAME}.md"
+
+DIFF_BEFORE_FILENAME_TEMPLATE = "{base}.before_{from_short}"
+DIFF_AFTER_FILENAME_TEMPLATE = "{base}.after_{to_short}"
+DIFF_DIFF_FILENAME_TEMPLATE = "{base}.diff_{from_short}_to_{to_short}"
 
 class _OneOrTwoArgsAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
@@ -124,17 +129,76 @@ class DocBuilder:
             elif len(args.diff) > 2:
                 raise ValueError(f"At most 2 arguments for --diff - got {len(args.diff)}")
         args.output.mkdir(parents=True, exist_ok=True)
-        artifacts_dir = self.get_artifacts_dir(args.output)
-        artifacts_dir.mkdir(parents=True, exist_ok=True)
 
         if args.diff:
-            combined = self.generate_combined_diff(
+            before_md, after_md, diff_md, from_short, to_short = self.generate_combined_diff(
                 args, args.diff[0], args.diff[1]
             )
-            filename = combined.stem
+            base = self.get_file_base_name()
+
+            # For an apples to apples comparison, we do a "final" render of the
+            # full 3x3 matrix of:
+            #  (before, after, diff) x (html, md, pdf)
+            self._render_combined(
+                args,
+                combined=before_md,
+                filename=DIFF_BEFORE_FILENAME_TEMPLATE.format(base=base, from_short=from_short),
+                skip_docx=True,
+                output_dir=args.output / "diff_from",
+            )
+            self._render_combined(
+                args,
+                combined=after_md,
+                filename=DIFF_AFTER_FILENAME_TEMPLATE.format(base=base, to_short=to_short),
+                skip_docx=True,
+                output_dir=args.output / "diff_to",
+            )
+            return self._render_combined(
+                args,
+                combined=diff_md,
+                filename=DIFF_DIFF_FILENAME_TEMPLATE.format(base=base, from_short=from_short, to_short=to_short),
+                skip_docx=True,
+                output_dir=args.output / "diff",
+            )
+            # If everything succeeds, we should have an output tree like this
+            # (not complete -other intermediate files will exist too...)
+            # ├── build
+            # │   ├── diff
+            # │   │   ├── aousd_doc_build.diff_<fromhash>_to_<tohash>.html,
+            # │   │   ├── aousd_doc_build.diff_<fromhash>_to_<tohash>.md
+            # │   │   ├── aousd_doc_build.diff_<fromhash>_to_<tohash>.pdf
+            # │   │   ├── images
+            # │   │   │   ├── ...
+            # │   ├── diff_from
+            # │   │   ├── aousd_doc_build.before_<fromhash>.html
+            # │   │   ├── aousd_doc_build.before_<fromhash>.md
+            # │   │   ├── aousd_doc_build.before_<fromhash>.pdf
+            # │   │   └── images
+            # │   │       ├── ...
+            # │   └── diff_to
+            # │       ├── aousd_doc_build.after_<tohash>.html
+            # │       ├── aousd_doc_build.after_<tohash>.md
+            # │       ├── aousd_doc_build.after_<tohash>.pdf
+            # │       └── images
+            # │           ├── ...
         else:
             combined = self._setup_and_preprocess(args)
-            filename = self.get_file_base_name()
+            return self._render_combined(args, combined, self.get_file_base_name())
+
+    def _render_combined(
+        self,
+        args,
+        combined,
+        filename,
+        *,
+        skip_docx=False,
+        output_dir: Path | None = None,
+    ):
+        """Render HTML, PDF, Markdown, and optionally DOCX from a combined markdown file."""
+        if output_dir is None:
+            output_dir = args.output
+        artifacts_dir = self.get_artifacts_dir(output_dir)
+        artifacts_dir.mkdir(parents=True, exist_ok=True)
 
         spec = self.get_metadata_defaults_file()
         subtitle = self.get_subtitle(spec)
@@ -202,11 +266,11 @@ class DocBuilder:
         md = None
 
         if not args.no_md:
-            md = args.output / f"{filename}.md"
+            md = output_dir / f"{filename}.md"
             md_template = self.get_scripts_root() / "template" / "default.md"
             bundle_images_filter = self.get_filter("bundle_images")
             bundle_images_args = [
-                "-M", f"AOUSD_OUTPUT_DIR={args.output}",
+                "-M", f"AOUSD_OUTPUT_DIR={output_dir}",
                 "-M", f"AOUSD_IMAGES_ROOT={artifacts_dir}",
                 "-F", bundle_images_filter,
             ]
@@ -214,7 +278,7 @@ class DocBuilder:
             pandoc(shared_command + bundle_images_args + ["-o", md, "--to", MARKDOWN_OUTPUT_FORMAT, f"--template={md_template}"])
 
         if not args.no_html:
-            html = args.output / f"{filename}.html"
+            html = output_dir / f"{filename}.html"
             html_template = self.get_scripts_root() / "template" / "default.html5"
             log(f"\tBuilding HTML to {html}...")
             pandoc(
@@ -231,7 +295,7 @@ class DocBuilder:
             )
 
         if not args.no_pdf:
-            pdf = args.output / f"{filename}.pdf"
+            pdf = output_dir / f"{filename}.pdf"
             latex_template = self.get_scripts_root() / "template" / "default.latex"
             log(f"\tBuilding PDF to {pdf}...")
 
@@ -264,8 +328,8 @@ class DocBuilder:
                 stderr_processor=stderr_processor,
             )
 
-        if not args.no_docx:
-            docx = args.output / f"{filename}.docx"
+        if not args.no_docx and not skip_docx:
+            docx = output_dir / f"{filename}.docx"
             log(f"\tBuilding DocX to {docx}...")
             pandoc(shared_command + ["-o", docx, "-F", self.get_filter("convert_svg")])
 
@@ -385,10 +449,17 @@ class DocBuilder:
                 pass
 
     def generate_combined_diff(self, args, from_ref, to_ref):
-        """Build combined diff markdown from two refs; returns path to diff_X_Y.md."""
+        """Build combined diff markdown from two refs.
+
+        Returns (before_md, after_md, diff_md, from_short, to_short).
+        """
         from_short = self.resolve_ref(from_ref, short=True)
         to_short = self.resolve_ref(to_ref, short=True)
-        diff_basename = f"diff_{from_short}_{to_short}"
+        diff_basename =DIFF_DIFF_FILENAME_TEMPLATE.format(
+            base=COMBINED_SPEC_BASENAME,
+            from_short=from_short,
+            to_short=to_short
+        )
         diff_dir = args.output / "diff"
         diff_dir.mkdir(parents=True, exist_ok=True)
         worktree_from = diff_dir / "wt_from"
@@ -429,7 +500,7 @@ class DocBuilder:
         pandoc(
             ["-f", "json", "-t", MARKDOWN_FORMAT, "-o", combined_diff_md, diff_ast_path]
         )
-        return combined_diff_md
+        return combined_from, combined_to, combined_diff_md, from_short, to_short
 
     def clean_docs(self, args):
         if args.output.exists():

--- a/tests/build_scripts/build_diff.py
+++ b/tests/build_scripts/build_diff.py
@@ -135,21 +135,22 @@ def build_diff(build_html: bool, build_pdf: bool) -> None:
         builder.build_docs(args)
 
         # Copy outputs to tests/build/ with diff_test-* naming
-        for pattern, dst_stem, num_expected in [
-            ("diff_from/artifacts/combined_spec.md", "diff_test-1-before", 1),
-            ("diff_to/artifacts/combined_spec.md",  "diff_test-2-after", 1),
-            ("*diff_*_*", "diff_test-3-diff", 3),
-        ]:
-            files = sorted(diff_output.glob(pattern))
-            if len(files) != num_expected:
-                raise RuntimeError(f"Expected {num_expected} files for {pattern}, got {len(files)}")
-            for src in files:
-                dst = BUILD_DIR / f"{dst_stem}{src.suffix}"
-                shutil.copy(src, dst)
-                print(f"  Written: {dst}")
-            images_src_dir = diff_output / "images"
+        for subdir_name in ("diff_from", "diff_to", "diff"):
+            source_subdir = diff_output / subdir_name
+            dest_subdir = BUILD_DIR / subdir_name
+            dest_subdir.mkdir(parents=True, exist_ok=True)
+            files = sorted(source_subdir.glob("aousd_doc_build.*"))
+
+            # we expect an output html, md, and pdf for each diff
+            if len(files) != 3:
+                raise RuntimeError(f"Expected {num_expected} files for {pattern}, got {len(files)}: {files}")
+            for source in files:
+                destination = dest_subdir / source.name
+                shutil.copy(source, destination)
+                print(f"  Written: {destination}")
+            images_src_dir = source_subdir / "images"
             if images_src_dir.is_dir():
-                images_dst_dir = BUILD_DIR / "images"
+                images_dst_dir = dest_subdir / "images"
                 print(f"  Copying images from {images_src_dir} to {images_dst_dir}")
                 shutil.copytree(images_src_dir, images_dst_dir, dirs_exist_ok=True)
 


### PR DESCRIPTION
For an apples to apples comparison, we do a "final" render of the full 3x3 matrix of:
  (before, after, diff) x (html, md, pdf)

Also make organization and naming more consistent - each of before/after/diff get their own output dir and images subdir

If everything succeeds, we should have an output tree like this (not complete -other intermediate files will exist too...)

├── build
│   ├── diff
│   │   ├── aousd_doc_build.diff_<fromhash>_to_<tohash>.html, │   │   ├── aousd_doc_build.diff_<fromhash>_to_<tohash>.md │   │   ├── aousd_doc_build.diff_<fromhash>_to_<tohash>.pdf │   │   ├── images
│   │   │   ├── ...
│   ├── diff_from
│   │   ├── aousd_doc_build.before_<fromhash>.html │   │   ├── aousd_doc_build.before_<fromhash>.md
│   │   ├── aousd_doc_build.before_<fromhash>.pdf
│   │   └── images
│   │       ├── ...
│   └── diff_to
│       ├── aousd_doc_build.after_<tohash>.html
│       ├── aousd_doc_build.after_<tohash>.md
│       ├── aousd_doc_build.after_<tohash>.pdf
│       └── images
│           ├── ...

  Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>