### PR TITLE
Fix H6 heading in PDF bookmarks and non-LaTeX output formats

### DIFF
--- a/doc_build/filters/filter_header6.py
+++ b/doc_build/filters/filter_header6.py
@@ -6,7 +6,7 @@ from pandocfilters import toJSONFilter, RawBlock, stringify
 def header_to_subsubparagraph(key, value, format, meta):
     if key == 'Header':
         level, attr, contents = value
-        if level == 6:
+        if level == 6 and format == 'latex':
             text = stringify(contents)
             return RawBlock('latex', f'\\subsubparagraph{{{text}}}')
 

--- a/doc_build/template/after-header-includes.latex
+++ b/doc_build/template/after-header-includes.latex
@@ -92,6 +92,11 @@ $endif$
 % Fix the potential TOC issue
 \makeatletter
 \newcommand{\l@subsubparagraph}{\@dottedtocline{6}{7em}{4em}}
+% hyperref uses \toclevel@<cmd> to determine PDF bookmark depth.
+% \titleclass does not set this, so without it bookmarks default to level 0
+% (top-level), causing H6 to appear as a root item and nesting all following
+% headings under it in the PDF viewer's outline pane.
+\def\toclevel@subsubparagraph{6}
 \makeatother
 
 \setcounter{secnumdepth}{6}

--- a/tests/specification/README.md
+++ b/tests/specification/README.md
@@ -9,6 +9,7 @@ and to ensure we reduce the risk of regressions.
 It is also a quick testbed for functionality.
 
 1. [Inlined](Inlined.md)
+2. [Header Levels](headers_levels.md)
 
 # Math Tests
 


### PR DESCRIPTION
Two issues were causing H6 (######) to appear incorrectly:

1. filter_header6.py was unconditionally converting H6 to a raw LaTeX \subsubparagraph block for all output formats. Added a `format == 'latex'` check so HTML and Markdown outputs receive native <h6>/######  headings instead of literal LaTeX.

2. hyperref uses \toclevel@<cmd> to determine PDF bookmark depth, but titlesec's \titleclass (which defines \subsubparagraph) does not set this counter. Without it, hyperref defaulted to level 0 (root), making H6 appear as a top-level item in the PDF viewer's outline and causing all subsequent headings to nest under it. Added \def\toclevel@subsubparagraph{6} after the \titleclass call in after-header-includes.latex to fix this.