### PR TITLE
Add --keep-pdf-latex flag to capture intermediate LaTeX from PDF builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -384,4 +384,7 @@ $RECYCLE.BIN/
 pixi.lock
 /.pixi
 
+# PyInstaller-built wrapper (generated artifact, Windows only)
+doc_build/tools/tectonic.exe
+
 # End of https://www.toptal.com/developers/gitignore/api/python,macos,windows,linux,pycharm,visualstudiocode

--- a/doc_build/doc_builder.py
+++ b/doc_build/doc_builder.py
@@ -112,6 +112,106 @@ tectonic = ExecCommand("tectonic")
 git = ExecCommand("git")
 
 
+def _ensure_windows_wrapper_exe(capture_wrapper: Path, wrapper_exe: Path) -> None:
+    """Build the tectonic.exe wrapper via PyInstaller if it does not exist or is stale.
+
+    Rebuilds if wrapper_exe is older than capture_wrapper (the Python source).
+    Uses `pixi exec pyinstaller` so PyInstaller need not be a permanent dependency.
+    """
+    if wrapper_exe.exists() and wrapper_exe.stat().st_mtime >= capture_wrapper.stat().st_mtime:
+        return
+
+    import tempfile
+
+    log("Building tectonic.exe wrapper via PyInstaller (one-time setup)...")
+    with tempfile.TemporaryDirectory() as tmp:
+        subprocess.run(
+            [
+                "pixi",
+                "exec",
+                "pyinstaller",
+                "--onefile",
+                "--name",
+                "tectonic",
+                "--distpath",
+                str(wrapper_exe.parent),
+                "--workpath",
+                tmp,
+                "--specpath",
+                tmp,
+                "--noconfirm",
+                str(capture_wrapper),
+            ],
+            check=True,
+        )
+
+
+def _call_wrapped_tectonic(
+    pandoc_cmd: list,
+    capture_wrapper: Path,
+    real_tectonic: str,
+    base_env: dict,
+    stderr_processor,
+    tex_file: Path,
+    media_dir: Path,
+) -> None:
+    """Run pandoc with the tectonic capture wrapper active.
+
+    Constructs the capture environment (TEX_CAPTURE_PATH, TEX_MEDIA_DIR,
+    REAL_TECTONIC_PATH) and invokes pandoc.
+
+    On Unix, injects the wrapper directory at the front of PATH so pandoc finds
+    our shebang wrapper before the real tectonic.
+
+    On Windows, pandoc ignores PATH and uses the tectonic that ships in the
+    same pixi environment directory.  The real tectonic.exe must be inside the
+    pixi project (i.e. pixi-managed); we temporarily rename it and drop the
+    pre-built wrapper exe in its place, restoring everything via try/finally.
+    Raises RuntimeError if the real tectonic is outside the pixi project.
+    """
+    capture_env = {
+        **base_env,
+        "TEX_CAPTURE_PATH": str(tex_file),
+        "TEX_MEDIA_DIR": str(media_dir),
+    }
+
+    if sys.platform != "win32":
+        run_env = {
+            **capture_env,
+            "REAL_TECTONIC_PATH": real_tectonic,
+            "PATH": f"{capture_wrapper.parent}{os.pathsep}{capture_env.get('PATH', '')}",
+        }
+        pandoc(pandoc_cmd, stderr_processor=stderr_processor, env=run_env)
+        return
+
+    # Windows: pandoc finds tectonic via its own install directory, not PATH.
+    # Resolve both paths before comparing to normalize mixed slashes and case.
+    # capture_wrapper is <scripts_root>/tools/tectonic; project root is two levels up.
+    pixi_project_root = capture_wrapper.parent.parent.parent.resolve()
+    real_path = Path(real_tectonic).resolve()
+    try:
+        real_path.relative_to(pixi_project_root)
+    except ValueError:
+        raise RuntimeError(
+            f"tectonic binary is outside the pixi project:\n"
+            f"  tectonic: {real_path}\n"
+            f"  project:  {pixi_project_root}\n"
+            "Cannot safely intercept it on Windows."
+        )
+
+    wrapper_exe = capture_wrapper.parent / "tectonic.exe"
+    _ensure_windows_wrapper_exe(capture_wrapper, wrapper_exe)
+    renamed = real_path.with_name("tectonic.original.exe")
+    real_path.rename(renamed)
+    try:
+        shutil.copy2(wrapper_exe, real_path)
+        run_env = {**capture_env, "REAL_TECTONIC_PATH": str(renamed)}
+        pandoc(pandoc_cmd, stderr_processor=stderr_processor, env=run_env)
+    finally:
+        real_path.unlink(missing_ok=True)
+        renamed.rename(real_path)
+
+
 class DocBuilder:
     def __init__(self, *, repo_root: Optional[Union[Path, str]] = None):
         super().__init__()
@@ -382,7 +482,7 @@ class DocBuilder:
                     )
                 else:
                     tex_file = output_dir / f"{filename}.tex"
-                    recreate_script = output_dir / "recreate_pdf.sh"
+                    recreate_script = output_dir / "recreate_pdf.py"
 
                     # A capture wrapper named "tectonic" intercepts the LaTeX pandoc
                     # pipes to tectonic, saves it to disk, then forwards to the real
@@ -391,38 +491,41 @@ class DocBuilder:
                     # not a full path).  The wrapper is found first because its parent
                     # dir is prepended to PATH.
                     capture_wrapper = self.get_scripts_root() / "tools" / "tectonic"
-                    # Ensure executable bit is set (can be lost when installed from git)
-                    _mode = capture_wrapper.stat().st_mode
-                    if not (_mode & stat.S_IXUSR):
-                        capture_wrapper.chmod(_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+                    # Ensure executable bit is set (can be lost when installed from git).
+                    if sys.platform != "win32":
+                        _mode = capture_wrapper.stat().st_mode
+                        if not (_mode & stat.S_IXUSR):
+                            capture_wrapper.chmod(_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
-                    capture_env = build_env.copy()
-                    capture_env["REAL_TECTONIC_PATH"] = tectonic.binary
-                    capture_env["TEX_CAPTURE_PATH"] = str(tex_file)
-                    capture_env["TEX_MEDIA_DIR"] = str(output_dir / "images")
-                    capture_env["PATH"] = f"{capture_wrapper.parent}:{capture_env.get('PATH', '')}"
+                    # casting to os-native path ensures consistent slashes - was getting paths like:
+                    #    C:\\doc_build\\.pixi\\envs\\default\\Library/bin\\tectonic.EXE
+                    tectonic_path = str(Path(tectonic.binary))
 
                     log(f"\tBuilding PDF to {pdf}...")
-                    pandoc(
+                    _call_wrapped_tectonic(
                         latex_cmd_base + ["--pdf-engine=tectonic", "-o", pdf],
-                        stderr_processor=stderr_processor,
-                        env=capture_env,
+                        capture_wrapper,
+                        tectonic_path,
+                        build_env,
+                        stderr_processor,
+                        tex_file=tex_file,
+                        media_dir=output_dir / "images",
                     )
 
+                    recreate_template = self.get_scripts_root() / "tools" / "recreate_pdf.py.template"
                     recreate_script.write_text(
-                        f"#!/bin/sh\n"
-                        f"set -e\n"
-                        "\n"
-                        f"SOURCE_DATE_EPOCH={source_date_epoch}\n"
-                        f"export SOURCE_DATE_EPOCH\n"
-                        f'SCRIPT_DIR=$(dirname "$0")\n'
-                        f'cd "${{SCRIPT_DIR}}"\n'
-                        f'{tectonic.binary} - --outdir . < "{tex_file.name}"\n'
-                        f"mv texput.pdf '{pdf.name}'\n"
+                        recreate_template.read_text(encoding="utf-8").format(
+                            source_date_epoch=source_date_epoch,
+                            tectonic_path=tectonic_path,
+                            tex_file_name=tex_file.name,
+                            pdf_name=pdf.name,
+                        ),
+                        encoding="utf-8",
                     )
-                    recreate_script.chmod(
-                        recreate_script.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
-                    )
+                    if sys.platform != "win32":
+                        recreate_script.chmod(
+                            recreate_script.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+                        )
 
                     log(f"\tCaptured LaTeX: {tex_file}")
                     log(f"\tTo recreate PDF from .tex: {recreate_script}")

--- a/doc_build/doc_builder.py
+++ b/doc_build/doc_builder.py
@@ -5,6 +5,7 @@ import inspect
 import os
 import re
 import shutil
+import stat
 import subprocess
 import sys
 import time
@@ -107,6 +108,7 @@ class ExecCommand:
 
 
 pandoc = ExecCommand("pandoc")
+tectonic = ExecCommand("tectonic")
 git = ExecCommand("git")
 
 
@@ -289,7 +291,6 @@ class DocBuilder:
                 "--number-sections=true",
                 "--from",
                 MARKDOWN_FORMAT,
-                "--pdf-engine=tectonic",
             ]
 
             if not args.no_draft:
@@ -335,7 +336,12 @@ class DocBuilder:
                 template_dir = self.get_scripts_root() / "template"
                 latex_template = template_dir / "default.latex"
                 latex_diff_preamble = template_dir / "latex_diff_preamble.tex"
-                log(f"\tBuilding PDF to {pdf}...")
+
+                # Fix the build timestamp so repeated runs produce bit-for-bit
+                # identical PDFs (affects embedded dates and pdf-trailer-id).
+                source_date_epoch = os.environ.get("SOURCE_DATE_EPOCH") or str(int(time.time()))
+                build_env = os.environ.copy()
+                build_env["SOURCE_DATE_EPOCH"] = source_date_epoch
 
                 def stderr_processor(std_err):
                     lines = std_err.splitlines()
@@ -362,13 +368,64 @@ class DocBuilder:
                         log(line, file=sys.stderr)
 
                 pdf_extra = [f"--include-in-header={latex_diff_preamble}"] if is_diff else []
-                pandoc(
-                    shared_command + [
-                        "-o", pdf,
-                        f"--template={latex_template}",
-                    ] + pdf_extra,
-                    stderr_processor=stderr_processor,
-                )
+                latex_cmd_base = shared_command + [
+                    f"--template={latex_template}",
+                ] + pdf_extra
+
+                if not getattr(args, "keep_pdf_latex", False):
+                    # Standard path: pandoc pipes directly to tectonic via stdin.
+                    log(f"\tBuilding PDF to {pdf}...")
+                    pandoc(
+                        latex_cmd_base + ["--pdf-engine=tectonic", "-o", pdf],
+                        stderr_processor=stderr_processor,
+                        env=build_env,
+                    )
+                else:
+                    tex_file = output_dir / f"{filename}.tex"
+                    recreate_script = output_dir / "recreate_pdf.sh"
+
+                    # A capture wrapper named "tectonic" intercepts the LaTeX pandoc
+                    # pipes to tectonic, saves it to disk, then forwards to the real
+                    # tectonic.  We use the bare engine name "--pdf-engine=tectonic" so
+                    # pandoc applies its own SVG pre-conversion (only triggered by name,
+                    # not a full path).  The wrapper is found first because its parent
+                    # dir is prepended to PATH.
+                    capture_wrapper = self.get_scripts_root() / "tools" / "tectonic"
+                    # Ensure executable bit is set (can be lost when installed from git)
+                    _mode = capture_wrapper.stat().st_mode
+                    if not (_mode & stat.S_IXUSR):
+                        capture_wrapper.chmod(_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+                    capture_env = build_env.copy()
+                    capture_env["REAL_TECTONIC_PATH"] = tectonic.binary
+                    capture_env["TEX_CAPTURE_PATH"] = str(tex_file)
+                    capture_env["TEX_MEDIA_DIR"] = str(output_dir / "images")
+                    capture_env["PATH"] = f"{capture_wrapper.parent}:{capture_env.get('PATH', '')}"
+
+                    log(f"\tBuilding PDF to {pdf}...")
+                    pandoc(
+                        latex_cmd_base + ["--pdf-engine=tectonic", "-o", pdf],
+                        stderr_processor=stderr_processor,
+                        env=capture_env,
+                    )
+
+                    recreate_script.write_text(
+                        f"#!/bin/sh\n"
+                        f"set -e\n"
+                        "\n"
+                        f"SOURCE_DATE_EPOCH={source_date_epoch}\n"
+                        f"export SOURCE_DATE_EPOCH\n"
+                        f'SCRIPT_DIR=$(dirname "$0")\n'
+                        f'cd "${{SCRIPT_DIR}}"\n'
+                        f'{tectonic.binary} - --outdir . < "{tex_file.name}"\n'
+                        f"mv texput.pdf '{pdf.name}'\n"
+                    )
+                    recreate_script.chmod(
+                        recreate_script.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+                    )
+
+                    log(f"\tCaptured LaTeX: {tex_file}")
+                    log(f"\tTo recreate PDF from .tex: {recreate_script}")
 
             if not args.no_docx and not skip_docx:
                 docx = output_dir / f"{filename}.docx"
@@ -869,6 +926,12 @@ class DocBuilder:
         )
         build_parser.add_argument(
             "--no-draft", help="Do not add draft watermark", action="store_true"
+        )
+        build_parser.add_argument(
+            "--keep-pdf-latex",
+            help="Capture the intermediate LaTeX when building PDF, alongside a "
+            "script to recreate the PDF from the .tex (implies tectonic wrapper)",
+            action="store_true",
         )
         build_parser.add_argument(
             "--diff",

--- a/doc_build/tools/recreate_pdf.py.template
+++ b/doc_build/tools/recreate_pdf.py.template
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Re-run tectonic on the captured .tex to regenerate the PDF."""
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+SOURCE_DATE_EPOCH = {source_date_epoch!r}
+TECTONIC = {tectonic_path!r}
+TEX_FILE = {tex_file_name!r}
+PDF_NAME = {pdf_name!r}
+
+env = os.environ.copy()
+env["SOURCE_DATE_EPOCH"] = SOURCE_DATE_EPOCH
+# Font paths in the .tex are relative to artifacts_dir;
+# run tectonic from there so they resolve correctly.
+ARTIFACTS_DIR = SCRIPT_DIR / "artifacts"
+ARTIFACTS_DIR.mkdir(exist_ok=True, parents=True)
+with open(SCRIPT_DIR / TEX_FILE, "rb") as tex_in:
+    result = subprocess.run(
+        [TECTONIC, "-", "--outdir", str(SCRIPT_DIR)],
+        stdin=tex_in,
+        cwd=ARTIFACTS_DIR,
+        env=env,
+    )
+if result.returncode != 0:
+    sys.exit(result.returncode)
+(SCRIPT_DIR / "texput.pdf").rename(SCRIPT_DIR / PDF_NAME)

--- a/doc_build/tools/tectonic
+++ b/doc_build/tools/tectonic
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Pandoc PDF-engine wrapper: captures intermediate LaTeX then forwards to tectonic.
+
+When pandoc generates a PDF via --pdf-engine, it pipes the intermediate LaTeX
+to the engine via stdin (passing "-" as an argument).  This wrapper intercepts
+that stream, optionally saves it to disk, then forwards it to the real tectonic
+binary unchanged.
+
+Named "tectonic" so pandoc uses stdin mode when passed as --pdf-engine.
+
+After saving the .tex, any image paths inside pandoc's temp media directory
+are copied to a stable directory and the saved .tex is rewritten to use those
+stable paths.  This lets a subsequent tectonic invocation compile the .tex
+after pandoc has exited and cleaned up its temps.
+
+Environment variables:
+  REAL_TECTONIC_PATH  Path to the real tectonic binary (required).
+  TEX_CAPTURE_PATH    Path to write the captured LaTeX to (optional).
+  TEX_MEDIA_DIR       Directory to copy temp media into (optional; defaults
+                      to the directory containing TEX_CAPTURE_PATH).
+"""
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def stabilize_tex_media(tex_path: Path, media_dir: Path) -> None:
+    """Copy pandoc temp-dir media into media_dir and rewrite paths in the .tex.
+
+    Pandoc extracts images to a short-lived temp directory.  The captured
+    .tex references those temp paths.  This function copies each temp file
+    into media_dir and rewrites the .tex in-place so the via-tex tectonic
+    run can find the images after pandoc has exited.
+    """
+    content = tex_path.read_text(encoding="utf-8")
+
+    # Match any absolute /tmp/... path followed by a file extension.
+    temp_path_re = re.compile(r"/tmp/[^\s{}\\]+\.[A-Za-z]+")
+
+    replacements = {}
+    for match in temp_path_re.finditer(content):
+        orig = match.group(0)
+        if orig in replacements:
+            continue
+        src = Path(orig)
+        if not src.exists():
+            continue
+        dest = media_dir / src.name
+        shutil.copy2(src, dest)
+        replacements[orig] = os.path.relpath(dest, tex_path.parent)
+
+    if not replacements:
+        return
+
+    for orig, stable in replacements.items():
+        content = content.replace(orig, stable)
+    tex_path.write_text(content, encoding="utf-8")
+
+
+def main():
+    real_tectonic = os.environ.get("REAL_TECTONIC_PATH")
+    if not real_tectonic:
+        sys.exit("REAL_TECTONIC_PATH is not set")
+
+    latex_bytes = sys.stdin.buffer.read()
+
+    capture_path = os.environ.get("TEX_CAPTURE_PATH")
+    if capture_path:
+        tex_path = Path(capture_path)
+        tex_path.write_bytes(latex_bytes)
+
+        media_dir_env = os.environ.get("TEX_MEDIA_DIR")
+        media_dir = Path(media_dir_env) if media_dir_env else tex_path.parent
+        media_dir.mkdir(parents=True, exist_ok=True)
+        stabilize_tex_media(tex_path, media_dir)
+
+    result = subprocess.run([real_tectonic] + sys.argv[1:], input=latex_bytes)
+    sys.exit(result.returncode)
+
+
+if __name__ == "__main__":
+    main()

--- a/doc_build/tools/tectonic
+++ b/doc_build/tools/tectonic
@@ -25,33 +25,58 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
+
+
+def _make_temp_path_re() -> re.Pattern:
+    """Return a regex matching absolute paths under the OS temp directory."""
+    if sys.platform == "win32":
+        # On Windows, pandoc writes temp-dir paths using forward slashes in
+        # .tex files.  Build the pattern from the actual temp directory so it
+        # adapts to custom %TEMP% locations.
+        tmp = Path(tempfile.gettempdir()).as_posix()
+        return re.compile(rf"{re.escape(tmp)}/[^\s{{}}]+\.[A-Za-z]+", re.IGNORECASE)
+    else:
+        return re.compile(r"/tmp/[^\s{}\\]+\.[A-Za-z]+")
+
+
+_TEMP_PATH_RE = _make_temp_path_re()
+
+# Matches pandoc's relative temp media dirs: media-{hex}/<filename>.<ext>
+# These are written relative to the CWD (artifacts_dir) and deleted after pandoc exits.
+_MEDIA_REL_PATH_RE = re.compile(r"media-[0-9a-f]+/[^\s{}]+\.[A-Za-z]+")
 
 
 def stabilize_tex_media(tex_path: Path, media_dir: Path) -> None:
     """Copy pandoc temp-dir media into media_dir and rewrite paths in the .tex.
 
-    Pandoc extracts images to a short-lived temp directory.  The captured
-    .tex references those temp paths.  This function copies each temp file
-    into media_dir and rewrites the .tex in-place so the via-tex tectonic
-    run can find the images after pandoc has exited.
+    Handles two cases:
+    - Absolute paths under the OS temp directory (Unix-style pandoc behaviour).
+    - Relative media-{hex}/ paths written by pandoc relative to its CWD
+      (artifacts_dir), which pandoc deletes after it exits.
+
+    Replacement paths are written relative to Path.cwd() (artifacts_dir when
+    the wrapper runs), which is also the CWD tectonic uses in recreate_pdf.py.
     """
     content = tex_path.read_text(encoding="utf-8")
-
-    # Match any absolute /tmp/... path followed by a file extension.
-    temp_path_re = re.compile(r"/tmp/[^\s{}\\]+\.[A-Za-z]+")
+    cwd = Path.cwd()
 
     replacements = {}
-    for match in temp_path_re.finditer(content):
-        orig = match.group(0)
-        if orig in replacements:
-            continue
-        src = Path(orig)
-        if not src.exists():
-            continue
-        dest = media_dir / src.name
-        shutil.copy2(src, dest)
-        replacements[orig] = os.path.relpath(dest, tex_path.parent)
+    for pattern in (_TEMP_PATH_RE, _MEDIA_REL_PATH_RE):
+        for match in pattern.finditer(content):
+            orig = match.group(0)
+            if orig in replacements:
+                continue
+            src = Path(orig)
+            if not src.is_absolute():
+                src = cwd / src
+            if not src.exists():
+                continue
+            dest = media_dir / src.name
+            shutil.copy2(src, dest)
+            # Use forward slashes: LaTeX requires them even on Windows.
+            replacements[orig] = Path(os.path.relpath(dest, cwd)).as_posix()
 
     if not replacements:
         return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ doc_build = { path = ".", editable = true }
 [tool.pixi.tasks]
 build = "python tests/build_scripts/build_docs.py build"
 build-diff = "python tests/build_scripts/build_diff.py"
-test = { depends-on = ["build", "build-diff"] }
+test = { cmd = "python -c 'import sys; sys.argv[1:] and sys.exit(\"test does not accept extra args; pass them directly to build or build-diff\")'", depends-on = ["build", "build-diff"] }
 
 [tool.pixi.workspace]
 channels = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,22 @@ doc_build = { path = ".", editable = true }
 [tool.pixi.tasks]
 build = "python tests/build_scripts/build_docs.py build"
 build-diff = "python tests/build_scripts/build_diff.py"
-test = { cmd = "python -c 'import sys; sys.argv[1:] and sys.exit(\"test does not accept extra args; pass them directly to build or build-diff\")'", depends-on = ["build", "build-diff"] }
+
+[tool.pixi.tasks.test]
+    # Convenience command to run both build and build-diff
+    #   ie, `pixi run test` = `pixi run build ; pixi run build-diff`
+    # Note that `test` / depends-on tasks cannot be passed extra arguments...
+    # (see note below)
+    depends-on = ["build", "build-diff"]
+
+    # NOTE: this cmd is just to cause an error message to print if you try to pass args
+    # to `pixi run test`
+    # The pixi implementation of `depends-on`,does not forward extra command-line args,
+    # or error if they are present - so doing, ie:
+    #     pixi run test --keep-pdf-latexn
+    # ...will seem to work, but actually the flag is just silently discarded.
+    # This command causes the test task to fail in this scenario
+    cmd = "python -c 'import sys; sys.argv[1:] and sys.exit(\"test does not accept extra args; pass them directly to build or build-diff\")'"
 
 [tool.pixi.workspace]
 channels = [

--- a/tests/build_scripts/build_diff.py
+++ b/tests/build_scripts/build_diff.py
@@ -147,8 +147,8 @@ def build_diff(build_html: bool, build_pdf: bool, keep_pdf_latex: bool = False) 
         if keep_pdf_latex:
             # should also be a .tex file...
             expected_nums["aousd_doc_build.*"] += 1
-            # ... and a recreate_pdf.sh file
-            expected_nums["recreate_pdf.sh"] = 1
+            # ... and a recreate_pdf.py file
+            expected_nums["recreate_pdf.py"] = 1
 
         for subdir_name in ("diff_from", "diff_to", "diff"):
             source_subdir = diff_output / subdir_name

--- a/tests/build_scripts/build_diff.py
+++ b/tests/build_scripts/build_diff.py
@@ -104,7 +104,7 @@ def _setup_temp_repo(tmp: Path) -> tuple[str, str]:
     return before_sha, after_sha
 
 
-def build_diff(build_html: bool, build_pdf: bool) -> None:
+def build_diff(build_html: bool, build_pdf: bool, keep_pdf_latex: bool = False) -> None:
     for path in (FIXTURES_DIR / "before_commit", FIXTURES_DIR / "after_commit"):
         if not path.is_dir():
             raise FileNotFoundError(f"Missing fixture directory: {path}")
@@ -132,29 +132,39 @@ def build_diff(build_html: bool, build_pdf: bool) -> None:
             no_draft=True,
             only=[],
             exclude=[],
+            keep_pdf_latex=keep_pdf_latex,
         )
 
         print("Running DocBuilder.build_docs() with --diff...")
         builder.build_docs(args)
 
-        # md is always built; html and pdf are optional
-        num_expected = 1 + int(build_html) + int(build_pdf)
-
         # Copy outputs to tests/build/ with diff_test-* naming
+
+        expected_nums = {
+            # md is always built; html and pdf are optional
+            "aousd_doc_build.*": 1 + int(build_html) + int(build_pdf),
+        }
+        if keep_pdf_latex:
+            # should also be a .tex file...
+            expected_nums["aousd_doc_build.*"] += 1
+            # ... and a recreate_pdf.sh file
+            expected_nums["recreate_pdf.sh"] = 1
+
         for subdir_name in ("diff_from", "diff_to", "diff"):
             source_subdir = diff_output / subdir_name
             dest_subdir = BUILD_DIR / subdir_name
             dest_subdir.mkdir(parents=True, exist_ok=True)
+            all_source_files = []
+            for pattern, num_expected in expected_nums.items():
+                files = sorted(source_subdir.glob(pattern))
+                if len(files) != num_expected:
+                    raise RuntimeError(f"Expected {num_expected} files for pattern {pattern}, got {len(files)}: {files}")
+                all_source_files.extend(files)
 
-            glob_pattern = "aousd_doc_build.*"
-            files = sorted(source_subdir.glob(glob_pattern))
-
-            if len(files) != num_expected:
-                raise RuntimeError(f"Expected {num_expected} files for {glob_pattern}, got {len(files)}: {files}")
-            for source in files:
-                destination = dest_subdir / source.name
-                shutil.copy(source, destination)
-                print(f"  Written: {destination}")
+                for source in files:
+                    destination = dest_subdir / source.name
+                    shutil.copy(source, destination)
+                    print(f"  Written: {destination}")
             images_src_dir = source_subdir / "images"
             if images_src_dir.is_dir():
                 images_dst_dir = dest_subdir / "images"
@@ -174,6 +184,11 @@ def get_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--html", action="store_true", help="Build HTML output")
     parser.add_argument("--pdf", action="store_true", help="Build PDF output")
+    parser.add_argument(
+        "--keep-pdf-latex",
+        action="store_true",
+        help="Capture the intermediate LaTeX when building PDF (implies tectonic wrapper)",
+    )
     return parser
 
 
@@ -188,7 +203,7 @@ def main(argv=None) -> int:
     build_pdf = args.pdf or not any_specified
 
     try:
-        build_diff(build_html, build_pdf)
+        build_diff(build_html, build_pdf, keep_pdf_latex=args.keep_pdf_latex)
     except Exception:
         traceback.print_exc()
         return 1


### PR DESCRIPTION
Note: when debugging https://github.com/aousd/doc_build/pull/58, having access to the intermediate latex output used while generating the pdf was essential.

Since I thought that might be generally helpful, I added a flag to produce it.

I'm confirmed that the resulting pdf is bit-for-bit identical to one generated by the old / standard method... so we could potentially disable the flag, and just ALWAYS go through the path that generates the latex.

The argument for that would be that we could then archive the resulting latex along with the pdf - it could be helpful in the future, as having a "text version" of the PDF that we can run a standard text diff on could be helpful.

However... the method used to output the .latex has a fair amount of extra moving parts - ie, I use a tectonic wrapper script to capture the .tex input on stdin - and I thought maybe it would be best not to introduce extra required complexity.

- Add doc_build/tools/tectonic: a pandoc pdf-engine wrapper (named "tectonic" so pandoc uses stdin mode) that intercepts the LaTeX stream, saves it to TEX_CAPTURE_PATH, stabilizes /tmp image paths so the .tex remains compilable after pandoc exits, then forwards to REAL_TECTONIC_PATH
- Add --keep-pdf-latex flag: when set, prepends the wrapper's directory to PATH so pandoc picks it up by bare name, captures the .tex to the artifacts dir, and writes a recreate_pdf.sh script alongside it
- Set SOURCE_DATE_EPOCH for all PDF builds (respecting any existing env value) for reproducible, bit-for-bit identical builds