### PR TITLE
diff - in latex, ensure ALL block types have bg color set

### DIFF
--- a/doc_build/filters/filter_render_diff.py
+++ b/doc_build/filters/filter_render_diff.py
@@ -307,31 +307,18 @@ def _latex_block_bg_wrap(diff_class: str, content: List[Dict]) -> List[Dict]:
     )
 
 
-def _latex_codeblock_bg_blocks(block: Dict, diff_class: str) -> List[Dict]:
-    """Wrap a CodeBlock in shadecolor colorlet commands for LaTeX diff output.
+def _latex_bg_blocks(block: Dict, diff_class: str) -> List[Dict]:
+    """Wrap a block in a tcolorbox with a matching shadecolor for LaTeX diff output.
 
-    Returns three blocks: a RawBlock setting shadecolor to the pale diff
-    background, the CodeBlock itself, and a RawBlock resetting shadecolor to
-    pandoc's default (lightgray).  This works because pandoc's Shaded
-    environment uses shadecolor internally; \\colorbox cannot wrap verbatim.
-    """
-    bg = _LATEX_BLOCK_DIFF_BG[diff_class]
-    set_cmd = f"\\colorlet{{shadecolor}}{{{bg}}}"
-    reset_cmd = f"\\colorlet{{shadecolor}}{{{_LATEX_SHADECOLOR_DEFAULT}}}"
-    return [
-        {"t": "RawBlock", "c": ["latex", set_cmd]},
-        block,
-        {"t": "RawBlock", "c": ["latex", reset_cmd]},
-    ]
+    Returns five blocks: open tcolorbox, set shadecolor, the block, reset
+    shadecolor, close tcolorbox.
 
-
-def _latex_tcolorbox_bg_blocks(block: Dict, diff_class: str) -> List[Dict]:
-    """Wrap a block in a tcolorbox environment for LaTeX diff output.
-
-    Returns three blocks: a RawBlock opening the tcolorbox, the block itself,
-    and a RawBlock closing it.  This is used for Para/Plain blocks that contain
-    display math (\\[...\\]), which cannot be nested inside \\colorbox/\\parbox.
-    tcolorbox supports display math content without restriction.
+    Both mechanisms are always applied:
+    - tcolorbox provides the visible background for all block types.
+    - shadecolor is set to match inside the box so that CodeBlock's inner
+      Shaded environment blends with the tcolorbox background instead of
+      producing a double background.  For non-CodeBlock types, shadecolor is
+      not consulted by those environments, so the set/reset is a no-op.
     """
     bg = _LATEX_BLOCK_DIFF_BG[diff_class]
     open_cmd = (
@@ -341,33 +328,11 @@ def _latex_tcolorbox_bg_blocks(block: Dict, diff_class: str) -> List[Dict]:
     )
     return [
         {"t": "RawBlock", "c": ["latex", open_cmd]},
+        {"t": "RawBlock", "c": ["latex", f"\\colorlet{{shadecolor}}{{{bg}}}"]},
         block,
+        {"t": "RawBlock", "c": ["latex", f"\\colorlet{{shadecolor}}{{{_LATEX_SHADECOLOR_DEFAULT}}}"]},
         {"t": "RawBlock", "c": ["latex", "\\end{tcolorbox}"]},
     ]
-
-
-def _latex_apply_block_bg_blocks(block: Dict, diff_class: str) -> List[Dict]:
-    """Apply a pale-background wrapper to a block for LaTeX diff output.
-
-    Routes to the appropriate mechanism based on block type:
-    - CodeBlock: shadecolor colorlet commands (\\colorbox cannot wrap verbatim)
-    - Para/Plain with display math: tcolorbox environment (\\colorbox/\\parbox
-      cannot contain display math)
-    - Para/Plain otherwise: inline \\colorbox/\\parbox wrapping
-    - Header: tcolorbox environment (\\colorbox/\\parbox cause layout issues in headings)
-    - Other block types: returned unchanged, as a single-item list
-    """
-    t = block.get("t")
-    if t == "CodeBlock":
-        return _latex_codeblock_bg_blocks(block, diff_class)
-    if t in ("Para", "Plain"):
-        inlines = block["c"]
-        if _has_display_math(inlines):
-            return _latex_tcolorbox_bg_blocks(block, diff_class)
-        return [{"t": t, "c": _latex_block_bg_wrap(diff_class, inlines)}]
-    if t == "Header":
-        return _latex_tcolorbox_bg_blocks(block, diff_class)
-    return [block]
 
 
 def render_span_inlines(inlines: List[Dict], format: str) -> List[Dict]:
@@ -600,18 +565,8 @@ def handle_whole_block(
         return result
     result = []
     for block in content:
-        if format == "latex" and block.get("t") == "CodeBlock":
-            result.extend(_latex_codeblock_bg_blocks(block, diff_class))
-        elif (
-            format == "latex"
-            and block.get("t") in ("Para", "Plain")
-            and _has_display_math(block["c"])
-        ):
-            rendered = render_whole_block(block, format, diff_class)
-            result.extend(_latex_tcolorbox_bg_blocks(rendered, diff_class))
-        elif format == "latex" and block.get("t") == "Header":
-            rendered = render_whole_block(block, format, diff_class)
-            result.extend(_latex_tcolorbox_bg_blocks(rendered, diff_class))
+        if format == "latex":
+            result.extend(_latex_bg_blocks(block, diff_class))
         else:
             result.append(render_whole_block(block, format, diff_class))
     return result
@@ -672,9 +627,7 @@ def handle_substitution(content: List[Dict], format: str) -> List[Dict]:
             + _gfm_prefix_blocks(new_result, "insertion")
         )
     if format == "latex":
-        return _latex_apply_block_bg_blocks(
-            old_result, "deletion"
-        ) + _latex_apply_block_bg_blocks(new_result, "insertion")
+        return _latex_bg_blocks(old_result, "deletion") + _latex_bg_blocks(new_result, "insertion")
     return [old_result, new_result]
 
 

--- a/tests/diff_specification/after_commit/README.md
+++ b/tests/diff_specification/after_commit/README.md
@@ -68,3 +68,87 @@ SVG - Unchanged
 PNG - Unchanged
 
 ![Unchanged circle PNG](images/unchanged_circle.png)
+
+## Numbered Lists
+
+### Unchanged
+
+This list is present in both versions without any modifications.
+
+1. Alpha: this item does not change
+2. Beta: this item also stays the same
+3. Gamma: the final item is also unchanged
+
+### Bit That Stays the Same
+
+...just so that the removed and added sub-sections are not paired as a substitution.
+
+### Added
+
+This entire section and its list appear only in the after version.
+
+1. This list did not exist in the previous version
+2. All of these items are brand new additions
+3. The entire section was inserted during this revision
+
+### Mixed Changes
+
+This section exists in both versions but the list has several types of changes.
+
+1. This item will stay the same throughout both versions
+2. This item is unchanged; it separates the deletion above from the replacements below
+3. This item replaces the old third entry with completely new text
+4. This item will have just one word modified
+5. This item will also be kept in the list without any changes
+6. This brand new item was added to the end of the list
+
+### Flat to Correct Numbering
+
+This list uses repeated "1." numbering, while the after version uses correct sequential numbers.
+
+1. First item in this list
+2. Second item in this list
+3. Third item in this list
+4. Fourth item in this list
+
+### Random to Different Random Numbering
+
+This list uses one arbitrary numbering scheme; the after version uses a different arbitrary scheme.
+
+4. First item in this list
+2. Second item in this list
+1. Third item in this list
+6. Fourth item in this list
+
+## Unordered Lists
+
+### Unchanged
+
+This list is present in both versions without any modifications.
+
+- Alpha: this item does not change
+- Beta: this item also stays the same
+- Gamma: the final item is also unchanged
+
+### Bit That Stays the Same
+
+...just so that the removed and added sub-sections are not paired as a substitution.
+
+### Added
+
+This entire section and its list appear only in the after version.
+
+- This list did not exist in the previous version
+- All of these items are brand new additions
+- The entire section was inserted during this revision
+
+### Mixed Changes
+
+This section exists in both versions but the list has several types of changes.
+
+- This item will stay the same throughout both versions
+- This item is unchanged; it separates the deletion above from the replacements below
+- This item replaces the old third entry with completely new text
+- This item will have just one word modified
+- This item will also be kept in the list without any changes
+- This brand new item was added to the end of the list

--- a/tests/diff_specification/before_commit/README.md
+++ b/tests/diff_specification/before_commit/README.md
@@ -66,3 +66,87 @@ SVG - Unchanged
 PNG - Unchanged
 
 ![Unchanged circle PNG](images/unchanged_circle.png)
+
+## Numbered Lists
+
+### Unchanged
+
+This list is present in both versions without any modifications.
+
+1. Alpha: this item does not change
+2. Beta: this item also stays the same
+3. Gamma: the final item is also unchanged
+
+### Removed
+
+This entire section and its list are present only in the before version.
+
+1. This list will be completely removed
+2. None of these items survive to the after version
+3. The entire section disappears in the next revision
+
+### Bit That Stays the Same
+
+...just so that the removed and added sub-sections are not paired as a substitution.
+
+### Mixed Changes
+
+This section exists in both versions but the list has several types of changes.
+
+1. This item will stay the same throughout both versions
+2. This item will be completely removed from the list
+3. This item is unchanged; it separates the deletion above from the replacements below
+4. This item will be fully replaced with entirely different content
+5. This item will have just one word altered
+6. This item will also be kept in the list without any changes
+
+### Flat to Correct Numbering
+
+This list uses repeated "1." numbering, while the after version uses correct sequential numbers.
+
+1. First item in this list
+1. Second item in this list
+1. Third item in this list
+1. Fourth item in this list
+
+### Random to Different Random Numbering
+
+This list uses one arbitrary numbering scheme; the after version uses a different arbitrary scheme.
+
+3. First item in this list
+1. Second item in this list
+5. Third item in this list
+2. Fourth item in this list
+
+## Unordered Lists
+
+### Unchanged
+
+This list is present in both versions without any modifications.
+
+- Alpha: this item does not change
+- Beta: this item also stays the same
+- Gamma: the final item is also unchanged
+
+### Removed
+
+This entire section and its list are present only in the before version.
+
+- This list will be completely removed
+- None of these items survive to the after version
+- The entire section disappears in the next revision
+
+### Bit That Stays the Same
+
+...just so that the removed and added sub-sections are not paired as a substitution.
+
+### Mixed Changes
+
+This section exists in both versions but the list has several types of changes.
+
+- This item will stay the same throughout both versions
+- This item will be completely removed from the list
+- This item is unchanged; it separates the deletion above from the replacements below
+- This item will be fully replaced with entirely different content
+- This item will have just one word altered
+- This item will also be kept in the list without any changes


### PR DESCRIPTION
previously, was using fragile system where specific block types were getting background-color-via-tcolorbox, other specific block types were getting background-color-via-shadecolor, and all other unknown types were getting nothing.

Now, we have an approach of always-apply-both-tcolorbox-and-shadecolor

- tcolorbox provides the visible background for all block types.
- shadecolor is set to match inside the box so that CodeBlock's inner Shaded environment blends with the tcolorbox background instead of producing a double background.  For non-CodeBlock types, shadecolor is not consulted by those environments, so the set/reset is a no-op.