### PR TITLE
    diff - fix blockquote background color in PDF diffs

### DIFF
--- a/doc_build/filters/filter_render_diff.py
+++ b/doc_build/filters/filter_render_diff.py
@@ -99,6 +99,8 @@ _LATEX_MATH_TEXT_CMD = {
 }
 # pandoc's default shadecolor for Shaded/verbatim environments
 _LATEX_SHADECOLOR_DEFAULT = "lightgray"
+# notebg default color name (defined via \colorlet{notebgdefault}{notebg} in after-header-includes.latex)
+_LATEX_NOTEBG_DEFAULT = "notebgdefault"
 
 
 ###############################################################################
@@ -308,30 +310,40 @@ def _latex_block_bg_wrap(diff_class: str, content: List[Dict]) -> List[Dict]:
 
 
 def _latex_bg_blocks(block: Dict, diff_class: str) -> List[Dict]:
-    """Wrap a block in a tcolorbox with a matching shadecolor for LaTeX diff output.
+    """Apply a diff background to a block for LaTeX output.
 
-    Returns five blocks: open tcolorbox, set shadecolor, the block, reset
-    shadecolor, close tcolorbox.
+    Wraps the block in a tcolorbox and sets shadecolor and notebg to match.
+    All three are applied unconditionally so that background-bearing children
+    at any nesting depth inherit the diff color:
 
-    Both mechanisms are always applied:
-    - tcolorbox provides the visible background for all block types.
-    - shadecolor is set to match inside the box so that CodeBlock's inner
-      Shaded environment blends with the tcolorbox background instead of
-      producing a double background.  For non-CodeBlock types, shadecolor is
-      not consulted by those environments, so the set/reset is a no-op.
+    - shadecolor: read by CodeBlock's Shaded/snugshade environment.
+    - notebg: read by BlockQuote's tcolorbox (colback=notebg).  The outer
+      tcolorbox cannot override an inner tcolorbox's colback, so setting notebg
+      is the only way to propagate the diff color into a BlockQuote.
+
+    Setting all three handles nested combinations correctly: a CodeBlock inside
+    a BlockQuote, a BulletList inside a BlockQuote, a CodeBlock inside a
+    BulletList inside a BlockQuote, etc.  The outer tcolorbox adds a thin layer
+    of extra padding around BlockQuote's own box (boxsep=0pt, left=2pt,
+    right=2pt, top=1pt, bottom=1pt), which is an acceptable trade-off.
     """
     bg = _LATEX_BLOCK_DIFF_BG[diff_class]
     open_cmd = (
+        f"\\colorlet{{shadecolor}}{{{bg}}}"
+        f"\\colorlet{{notebg}}{{{bg}}}"
         f"\\begin{{tcolorbox}}[colback={bg},colframe={bg},"
         "boxrule=0pt,boxsep=0pt,left=2pt,right=2pt,top=1pt,bottom=1pt,"
         "enhanced,breakable]"
     )
+    close_cmd = (
+        f"\\end{{tcolorbox}}"
+        f"\\colorlet{{shadecolor}}{{{_LATEX_SHADECOLOR_DEFAULT}}}"
+        f"\\colorlet{{notebg}}{{{_LATEX_NOTEBG_DEFAULT}}}"
+    )
     return [
         {"t": "RawBlock", "c": ["latex", open_cmd]},
-        {"t": "RawBlock", "c": ["latex", f"\\colorlet{{shadecolor}}{{{bg}}}"]},
         block,
-        {"t": "RawBlock", "c": ["latex", f"\\colorlet{{shadecolor}}{{{_LATEX_SHADECOLOR_DEFAULT}}}"]},
-        {"t": "RawBlock", "c": ["latex", "\\end{tcolorbox}"]},
+        {"t": "RawBlock", "c": ["latex", close_cmd]},
     ]
 
 

--- a/doc_build/template/after-header-includes.latex
+++ b/doc_build/template/after-header-includes.latex
@@ -12,6 +12,7 @@ $endif$
 % set the notes to have an orange color
 \usepackage[most]{tcolorbox}
 \definecolor{notebg}{RGB}{255,255,204}
+\colorlet{notebgdefault}{notebg}
 \tcbset{
   blockquote/.style={
     colback=notebg,

--- a/tests/diff_specification/after_commit/README.md
+++ b/tests/diff_specification/after_commit/README.md
@@ -150,6 +150,17 @@ This section exists in both versions but the list has several types of changes.
 - This item is unchanged; it separates the deletion above from the replacements below
 - This item replaces the old third entry with completely new text
 - This item will have just one word modified
+
+- This item contains a blockquote that will be modified:
+
+    > This blockquote content comes from the after version.
+
+- This item contains a code block that will be modified:
+
+    ```python
+    result = new_function()
+    ```
+
 - This item will also be kept in the list without any changes
 - This brand new item was added to the end of the list
 

--- a/tests/diff_specification/after_commit/README.md
+++ b/tests/diff_specification/after_commit/README.md
@@ -153,6 +153,42 @@ This section exists in both versions but the list has several types of changes.
 - This item will also be kept in the list without any changes
 - This brand new item was added to the end of the list
 
+## Block Quotes
+
+### Unchanged
+
+This blockquote is identical in both versions.
+
+> This blockquote paragraph is unchanged throughout both versions.
+>
+> This second paragraph is also identical in before and after.
+
+### Bit That Stays the Same
+
+...just so that the removed and added sub-sections are not paired as a substitution.
+
+### Added
+
+This entire section and its blockquote appear only in the after version.
+
+> This blockquote did not exist in the previous version.
+>
+> All of these paragraphs are brand new additions.
+
+### Mixed Changes
+
+This blockquote exists in both versions but has internal changes.
+
+> This paragraph will stay the same throughout both versions.
+>
+> This paragraph is unchanged; it separates the deletion above from the replacements below.
+>
+> This paragraph replaces the old fourth entry with completely new text.
+>
+> This paragraph will have just one word modified.
+>
+> This final paragraph will also be kept without any changes.
+
 ## Line Blocks
 
 ### Unchanged

--- a/tests/diff_specification/after_commit/README.md
+++ b/tests/diff_specification/after_commit/README.md
@@ -161,6 +161,16 @@ This section exists in both versions but the list has several types of changes.
     result = new_function()
     ```
 
+- This item contains a blockquote with a nested code block that will be modified:
+
+    > Text before the nested code block.
+    >
+    > ```python
+    > nested = new_nested()
+    > ```
+    >
+    > Text after the nested code block.
+
 - This item will also be kept in the list without any changes
 - This brand new item was added to the end of the list
 
@@ -185,6 +195,18 @@ This entire section and its blockquote appear only in the after version.
 > This blockquote did not exist in the previous version.
 >
 > All of these paragraphs are brand new additions.
+
+### Changed Block Quote With Code Block
+
+This blockquote contains a nested code block and will be modified.
+
+> Some introductory text before the code.
+>
+> ```python
+> result = new_function()
+> ```
+>
+> Some concluding text after the code.
 
 ### Mixed Changes
 

--- a/tests/diff_specification/before_commit/README.md
+++ b/tests/diff_specification/before_commit/README.md
@@ -149,6 +149,17 @@ This section exists in both versions but the list has several types of changes.
 - This item is unchanged; it separates the deletion above from the replacements below
 - This item will be fully replaced with entirely different content
 - This item will have just one word altered
+
+- This item contains a blockquote that will be modified:
+
+    > This blockquote content comes from the before version.
+
+- This item contains a code block that will be modified:
+
+    ```python
+    result = old_function()
+    ```
+
 - This item will also be kept in the list without any changes
 
 ## Block Quotes

--- a/tests/diff_specification/before_commit/README.md
+++ b/tests/diff_specification/before_commit/README.md
@@ -160,6 +160,16 @@ This section exists in both versions but the list has several types of changes.
     result = old_function()
     ```
 
+- This item contains a blockquote with a nested code block that will be modified:
+
+    > Text before the nested code block.
+    >
+    > ```python
+    > nested = old_nested()
+    > ```
+    >
+    > Text after the nested code block.
+
 - This item will also be kept in the list without any changes
 
 ## Block Quotes
@@ -183,6 +193,18 @@ This entire section and its blockquote are present only in the before version.
 ### Bit That Stays the Same
 
 ...just so that the removed and added sub-sections are not paired as a substitution.
+
+### Changed Block Quote With Code Block
+
+This blockquote contains a nested code block and will be modified.
+
+> Some introductory text before the code.
+>
+> ```python
+> result = old_function()
+> ```
+>
+> Some concluding text after the code.
 
 ### Mixed Changes
 

--- a/tests/diff_specification/before_commit/README.md
+++ b/tests/diff_specification/before_commit/README.md
@@ -151,6 +151,44 @@ This section exists in both versions but the list has several types of changes.
 - This item will have just one word altered
 - This item will also be kept in the list without any changes
 
+## Block Quotes
+
+### Unchanged
+
+This blockquote is identical in both versions.
+
+> This blockquote paragraph is unchanged throughout both versions.
+>
+> This second paragraph is also identical in before and after.
+
+### Removed
+
+This entire section and its blockquote are present only in the before version.
+
+> This blockquote will be completely removed.
+>
+> None of these paragraphs survive to the after version.
+
+### Bit That Stays the Same
+
+...just so that the removed and added sub-sections are not paired as a substitution.
+
+### Mixed Changes
+
+This blockquote exists in both versions but has internal changes.
+
+> This paragraph will stay the same throughout both versions.
+>
+> This paragraph will be completely removed from the blockquote.
+>
+> This paragraph is unchanged; it separates the deletion above from the replacements below.
+>
+> This paragraph will be fully replaced with entirely different content.
+>
+> This paragraph will have just one word altered.
+>
+> This final paragraph will also be kept without any changes.
+
 ## Line Blocks
 
 ### Unchanged


### PR DESCRIPTION
BlockQuote renders as a tcolorbox with colback=notebg, so wrapping it in
an outer diff tcolorbox had no effect - the inner colback always wins.

Fix by also setting notebg (alongside the existing shadecolor) before
the diff tcolorbox, so blockquotes and any nested content (code blocks,
lists, etc.) all inherit the diff background color.

- Add \colorlet{notebgdefault}{notebg} in after-header-includes.latex
  as a restore target
- Set and restore notebg in _latex_bg_blocks alongside shadecolor
- Collapse the open and close raw blocks to 3 total (open, block, close)