### PR TITLE
diff - recursive diffing for nested iterable AST node types

### DIFF
--- a/doc_build/ast_diff.py
+++ b/doc_build/ast_diff.py
@@ -128,6 +128,8 @@ def _pair_adjacent_changes(blocks: NodeList) -> NodeList:
             d, ins = deletions[j], insertions[j]
             if _is_list_node(d) and _is_list_node(ins) and d.get("t") == ins.get("t"):
                 result.append(diff_list_nodes(d, ins))
+            elif d.get("t") == "BlockQuote" and ins.get("t") == "BlockQuote":
+                result.append(diff_block_quote_nodes(d, ins))
             elif d.get("t") == "LineBlock" and ins.get("t") == "LineBlock":
                 result.extend(diff_line_block_nodes(d, ins))
             else:
@@ -164,11 +166,11 @@ def _build_list_with_items(node: PandocNode, items: List[List[PandocNode]]) -> P
 
 
 def _item_to_block(item: List[PandocNode]) -> PandocNode:
-    """Convert a list item's blocks to a single block for substitution wrapping.
+    """Convert a list item's blocks to a single block for diff wrapping.
 
-    Single-block items are returned as-is (the common case: Plain or Para),
-    which lets the render filter apply word-level diffs.  Multi-block items
-    are wrapped in an anonymous Div so they can be passed to make_substitution_div.
+    Used for unpaired deletions/insertions.  Single-block items are returned
+    as-is (the common case: Plain or Para).  Multi-block items are wrapped in
+    an anonymous Div so they can be passed to add_diff_meta as a unit.
     """
     if len(item) == 1:
         return item[0]
@@ -243,18 +245,27 @@ def diff_list_nodes(old_node: PandocNode, new_node: PandocNode) -> PandocNode:
 
         n_pairs = min(len(deletions), len(insertions))
         for j in range(n_pairs):
-            result_items.append(
-                [make_substitution_div(
-                    _item_to_block(deletions[j]),
-                    _item_to_block(insertions[j]),
-                )]
-            )
+            result_items.append(diff_block_lists(deletions[j], insertions[j]))
         for del_item in deletions[n_pairs:]:
             result_items.append([add_diff_meta(_item_to_block(del_item), "deletion")])
         for ins_item in insertions[n_pairs:]:
             result_items.append([add_diff_meta(_item_to_block(ins_item), "insertion")])
 
     return _build_list_with_items(old_node, result_items)
+
+
+def diff_block_quote_nodes(old_node: PandocNode, new_node: PandocNode) -> PandocNode:
+    """Diff two BlockQuote nodes at the block level.
+
+    Recursively diffs the content blocks of both BlockQuotes and returns a
+    single reconstructed BlockQuote whose contents carry per-block
+    insertion/deletion/substitution annotations.  Because the contents are
+    passed through diff_block_lists, any iterable types nested inside the
+    BlockQuote (lists, further BlockQuotes, LineBlocks) are themselves
+    recursively diffed.
+    """
+    diffed_blocks = diff_block_lists(old_node["c"], new_node["c"])
+    return {"t": "BlockQuote", "c": diffed_blocks}
 
 
 def _line_to_plain(line: List[PandocNode]) -> PandocNode:

--- a/tests/diff_specification/after_commit/README.md
+++ b/tests/diff_specification/after_commit/README.md
@@ -253,3 +253,50 @@ This line block exists in both versions but has internal changes.
 | This line replaces the old fourth entry with completely new text.
 | This line will have just one word modified.
 | This final line will also be kept without any changes.
+
+## Deeply Nested Structures
+
+### Multi-Level Bulleted List
+
+A two-level list where only one sub-item changes.
+
+- Top-level item A: unchanged throughout both versions
+- Top-level item B: has sub-items that will change
+    - Sub-item B1: this sub-item is unchanged
+    - Sub-item B2: this sub-item has been modified
+    - Sub-item B3: this sub-item is also unchanged
+- Top-level item C: unchanged throughout both versions
+
+### Nested Block Quotes
+
+A blockquote that contains another blockquote; only the inner one changes.
+
+> This outer paragraph is unchanged.
+>
+> > This inner blockquote paragraph has been modified.
+>
+> This other outer paragraph is also unchanged.
+
+### List Inside Block Quote
+
+A blockquote that contains a bulleted list; only one list item changes.
+
+> This introductory paragraph is unchanged.
+>
+> - This list item is unchanged throughout both versions.
+> - This list item has been modified.
+> - This list item is also unchanged.
+
+### Block Quote Inside Nested List
+
+A blockquote three levels deep (list item > sub-item > blockquote); only the quote text changes.
+
+- This top-level item is unchanged.
+- This item has nested sub-items:
+    - This sub-item is unchanged.
+    - This sub-item has a blockquote that will change:
+
+        > The after version of this deeply nested blockquote.
+
+    - This sub-item is also unchanged.
+- This last top-level item is also unchanged.

--- a/tests/diff_specification/after_commit/README.md
+++ b/tests/diff_specification/after_commit/README.md
@@ -300,3 +300,20 @@ A blockquote three levels deep (list item > sub-item > blockquote); only the quo
 
     - This sub-item is also unchanged.
 - This last top-level item is also unchanged.
+
+### Four-Level Mixed List
+
+A four-level mixed list (bullet > numbered > bullet > numbered) where only the deepest item changes.
+
+- Top-level bullet A: unchanged throughout both versions
+- Top-level bullet B: has a numbered sub-list
+    1. Numbered B1: unchanged
+    2. Numbered B2: has a bullet sub-sub-list
+        - Bullet B2a: unchanged
+        - Bullet B2b: has a numbered sub-sub-sub-list
+            1. Deepest item: unchanged
+            2. Deepest item: this one has been modified
+            3. Deepest item: also unchanged
+        - Bullet B2c: unchanged
+    3. Numbered B3: unchanged
+- Top-level bullet C: unchanged throughout both versions

--- a/tests/diff_specification/before_commit/README.md
+++ b/tests/diff_specification/before_commit/README.md
@@ -254,3 +254,50 @@ This line block exists in both versions but has internal changes.
 | This line will be fully replaced with entirely different content.
 | This line will have just one word altered.
 | This final line will also be kept without any changes.
+
+## Deeply Nested Structures
+
+### Multi-Level Bulleted List
+
+A two-level list where only one sub-item changes.
+
+- Top-level item A: unchanged throughout both versions
+- Top-level item B: has sub-items that will change
+    - Sub-item B1: this sub-item is unchanged
+    - Sub-item B2: this sub-item will be altered
+    - Sub-item B3: this sub-item is also unchanged
+- Top-level item C: unchanged throughout both versions
+
+### Nested Block Quotes
+
+A blockquote that contains another blockquote; only the inner one changes.
+
+> This outer paragraph is unchanged.
+>
+> > This inner blockquote paragraph will be changed.
+>
+> This other outer paragraph is also unchanged.
+
+### List Inside Block Quote
+
+A blockquote that contains a bulleted list; only one list item changes.
+
+> This introductory paragraph is unchanged.
+>
+> - This list item is unchanged throughout both versions.
+> - This list item will be changed.
+> - This list item is also unchanged.
+
+### Block Quote Inside Nested List
+
+A blockquote three levels deep (list item > sub-item > blockquote); only the quote text changes.
+
+- This top-level item is unchanged.
+- This item has nested sub-items:
+    - This sub-item is unchanged.
+    - This sub-item has a blockquote that will change:
+
+        > The before version of this deeply nested blockquote.
+
+    - This sub-item is also unchanged.
+- This last top-level item is also unchanged.

--- a/tests/diff_specification/before_commit/README.md
+++ b/tests/diff_specification/before_commit/README.md
@@ -301,3 +301,20 @@ A blockquote three levels deep (list item > sub-item > blockquote); only the quo
 
     - This sub-item is also unchanged.
 - This last top-level item is also unchanged.
+
+### Four-Level Mixed List
+
+A four-level mixed list (bullet > numbered > bullet > numbered) where only the deepest item changes.
+
+- Top-level bullet A: unchanged throughout both versions
+- Top-level bullet B: has a numbered sub-list
+    1. Numbered B1: unchanged
+    2. Numbered B2: has a bullet sub-sub-list
+        - Bullet B2a: unchanged
+        - Bullet B2b: has a numbered sub-sub-sub-list
+            1. Deepest item: unchanged
+            2. Deepest item: this one will be altered
+            3. Deepest item: also unchanged
+        - Bullet B2c: unchanged
+    3. Numbered B3: unchanged
+- Top-level bullet C: unchanged throughout both versions


### PR DESCRIPTION
Three changes to ast_diff.py:

- Add diff_block_quote_nodes() which diffs the content blocks of two
  BlockQuotes via diff_block_lists, enabling recursive per-block diffs
  inside blockquotes
- Add BlockQuote case to _pair_adjacent_changes() alongside the existing
  list and LineBlock special cases
- Change diff_list_nodes() substitution pairing to call
  diff_block_lists(d, ins) instead of make_substitution_div(_item_to_block(...))
  This closes the recursion loop: changed list items now route back through
  the full diffing pipeline, so any iterable type nested inside a list item
  (BlockQuote, nested list, LineBlock) gets recursively diffed rather than
  treated as an opaque substitution blob

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>