### PR TITLE
diff test - add another anchor paragraph to `Sections` portion

### DIFF
--- a/tests/diff_specification/after_commit/README.md
+++ b/tests/diff_specification/after_commit/README.md
@@ -55,6 +55,8 @@ In the range $0 \le x \le 2$, the function $f(x) = \sqrt{x}$ is monotonically in
 
 This paragraph will remain.
 
+Another anchor paragraph that stays unchanged.
+
 This is a brand new paragraph inserted into the document.
 
 This paragraph will also remain at the end.

--- a/tests/diff_specification/before_commit/README.md
+++ b/tests/diff_specification/before_commit/README.md
@@ -55,6 +55,8 @@ This paragraph will remain.
 
 This entire paragraph will be deleted from the document.
 
+Another anchor paragraph that stays unchanged.
+
 This paragraph will also remain at the end.
 
 ## Images


### PR DESCRIPTION
So that the tests that are supposed to test adding and removing of sections actually do so.

Without the anchor paragraph, that stays unchanged, inbetween the removed and added sections, they will simply be viewed (correctly) as a single substitution.