### PR TITLE
diff - per-line diffing for LineBlock nodes

### DIFF
--- a/doc_build/ast_diff.py
+++ b/doc_build/ast_diff.py
@@ -128,6 +128,8 @@ def _pair_adjacent_changes(blocks: NodeList) -> NodeList:
             d, ins = deletions[j], insertions[j]
             if _is_list_node(d) and _is_list_node(ins) and d.get("t") == ins.get("t"):
                 result.append(diff_list_nodes(d, ins))
+            elif d.get("t") == "LineBlock" and ins.get("t") == "LineBlock":
+                result.extend(diff_line_block_nodes(d, ins))
             else:
                 result.append(make_substitution_div(d, ins))
         for node in deletions[n_pairs:]:
@@ -253,6 +255,27 @@ def diff_list_nodes(old_node: PandocNode, new_node: PandocNode) -> PandocNode:
             result_items.append([add_diff_meta(_item_to_block(ins_item), "insertion")])
 
     return _build_list_with_items(old_node, result_items)
+
+
+def _line_to_plain(line: List[PandocNode]) -> PandocNode:
+    """Convert a LineBlock line (list of inlines) to a Plain block."""
+    return {"t": "Plain", "c": line}
+
+
+def diff_line_block_nodes(old_node: PandocNode, new_node: PandocNode) -> NodeList:
+    """Diff two LineBlock nodes at the line level.
+
+    Converts each line to a Plain block and delegates to diff_block_lists,
+    which handles LCS matching, pairing, and substitution Div creation.
+    Changed line pairs become substitution Divs wrapping Plain blocks, so
+    the render filter applies word-level diffs to each changed line.
+
+    Returns a flat NodeList rather than a single node; callers must use
+    extend() rather than append() when inserting into a block list.
+    """
+    old_blocks = [_line_to_plain(line) for line in old_node["c"]]
+    new_blocks = [_line_to_plain(line) for line in new_node["c"]]
+    return diff_block_lists(old_blocks, new_blocks)
 
 
 def diff_block_lists(before_blocks: NodeList, after_blocks: NodeList) -> NodeList:

--- a/tests/diff_specification/after_commit/README.md
+++ b/tests/diff_specification/after_commit/README.md
@@ -152,3 +152,35 @@ This section exists in both versions but the list has several types of changes.
 - This item will have just one word modified
 - This item will also be kept in the list without any changes
 - This brand new item was added to the end of the list
+
+## Line Blocks
+
+### Unchanged
+
+This line block is identical in both versions.
+
+| This line is unchanged throughout both versions.
+| This line is also identical in before and after.
+| This final line remains the same as well.
+
+### Bit That Stays the Same
+
+...just so that the removed and added sub-sections are not paired as a substitution.
+
+### Added
+
+This entire section and its line block appear only in the after version.
+
+| This line block did not exist in the previous version.
+| All of these lines are brand new additions.
+| The entire section was inserted during this revision.
+
+### Mixed Changes
+
+This line block exists in both versions but has internal changes.
+
+| This line will stay the same throughout both versions.
+| This line is unchanged; it separates the deletion above from the replacements below.
+| This line replaces the old fourth entry with completely new text.
+| This line will have just one word modified.
+| This final line will also be kept without any changes.

--- a/tests/diff_specification/before_commit/README.md
+++ b/tests/diff_specification/before_commit/README.md
@@ -150,3 +150,36 @@ This section exists in both versions but the list has several types of changes.
 - This item will be fully replaced with entirely different content
 - This item will have just one word altered
 - This item will also be kept in the list without any changes
+
+## Line Blocks
+
+### Unchanged
+
+This line block is identical in both versions.
+
+| This line is unchanged throughout both versions.
+| This line is also identical in before and after.
+| This final line remains the same as well.
+
+### Removed
+
+This entire section and its line block are present only in the before version.
+
+| This line block will be completely removed.
+| None of these lines survive to the after version.
+| The entire section disappears in the next revision.
+
+### Bit That Stays the Same
+
+...just so that the removed and added sub-sections are not paired as a substitution.
+
+### Mixed Changes
+
+This line block exists in both versions but has internal changes.
+
+| This line will stay the same throughout both versions.
+| This line will be completely removed from the line block.
+| This line is unchanged; it separates the deletion above from the replacements below.
+| This line will be fully replaced with entirely different content.
+| This line will have just one word altered.
+| This final line will also be kept without any changes.


### PR DESCRIPTION
- Add _line_to_plain() to convert a LineBlock line (list of inlines) to a Plain block
- Add diff_line_block_nodes() to diff two LineBlocks line-by-line via diff_block_lists
- Hook into _pair_adjacent_changes() so paired LineBlock substitutions expand into per-line Plain blocks with word-level diff support

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>