### PR TITLE
diff - add searchable labels to each diff change in output

### DIFF
--- a/doc_build/diff_colors.py
+++ b/doc_build/diff_colors.py
@@ -11,3 +11,4 @@ DIFF_SECTION_INS_PALE_GREEN = "e6ffec"  # pale green - block-level insertion bac
 DIFF_SECTION_DEL_PALE_RED   = "ffeef0"  # pale red   - block-level deletion background
 DIFF_WORD_INS_GREEN         = "acf2bd"  # green      - word-level insertion background
 DIFF_WORD_DEL_RED           = "ffb5bd"  # red        - word-level deletion background
+DIFF_COMMENT_GRAY           = "808080"  # gray       - diff comment text

--- a/doc_build/doc_builder.py
+++ b/doc_build/doc_builder.py
@@ -245,10 +245,13 @@ class DocBuilder:
         args.output.mkdir(parents=True, exist_ok=True)
 
         if args.diff:
+            from_ref, to_ref = args.diff[0], args.diff[1]
             before_md, after_md, diff_md, from_short, to_short = self.generate_combined_diff(
-                args, args.diff[0], args.diff[1]
+                args, from_ref, to_ref
             )
             base = self.get_file_base_name()
+            from_pretty = git_utils.get_ref_pretty_str(from_ref, self.get_repo_root())
+            to_pretty = git_utils.get_ref_pretty_str(to_ref, self.get_repo_root())
 
             # For an apples to apples comparison, we do a "final" render of the
             # full 3x3 matrix of:
@@ -274,6 +277,8 @@ class DocBuilder:
                 skip_docx=True,
                 is_diff=True,
                 output_dir=args.output / "diff",
+                from_pretty=from_pretty,
+                to_pretty=to_pretty,
             )
             # If everything succeeds, we should have an output tree like this
             # (not complete -other intermediate files will exist too...)
@@ -309,6 +314,8 @@ class DocBuilder:
         skip_docx=False,
         is_diff=False,
         output_dir: Path | None = None,
+        from_pretty: Optional[str] = None,
+        to_pretty: Optional[str] = None,
     ):
         """Render HTML, PDF, Markdown, and optionally DOCX from a combined markdown file."""
         if output_dir is None:
@@ -392,6 +399,12 @@ class DocBuilder:
             if not args.no_draft:
                 log("\tAdding Draft Watermark...")
                 shared_command.extend(["-V", "draft=true"])
+
+            if from_pretty is not None and to_pretty is not None:
+                shared_command.extend([
+                    "-M", f"diff-from-pretty={from_pretty}",
+                    "-M", f"diff-to-pretty={to_pretty}",
+                ])
 
             pdf = None
             docx = None

--- a/doc_build/filters/filter_render_diff.py
+++ b/doc_build/filters/filter_render_diff.py
@@ -728,18 +728,63 @@ def handle_substitution(content: List[Dict], format: str) -> List[Dict]:
 # Top-level filter function
 ###############################################################################
 
+_DIFF_TYPE_LABEL = {
+    "insertion": "Add",
+    "deletion": "Remove",
+    "substitution": "Substitution",
+}
+
+
+def _get_meta_str(meta: Dict, key: str) -> Optional[str]:
+    """Extract a plain string from pandoc metadata (MetaString or MetaInlines)."""
+    entry = meta.get(key)
+    if entry is None:
+        return None
+    t = entry.get("t")
+    if t == "MetaString":
+        return entry["c"]
+    if t == "MetaInlines":
+        parts = []
+        for node in entry["c"]:
+            nt = node.get("t")
+            if nt == "Str":
+                parts.append(node["c"])
+            elif nt == "Space":
+                parts.append(" ")
+        return "".join(parts)
+    return None
+
+
+def _make_diff_label_para(from_pretty: str, to_pretty: str, diff_type: str) -> Dict:
+    label = f"Diff - from {from_pretty} to {to_pretty} - {_DIFF_TYPE_LABEL[diff_type]}"
+    return {"t": "Para", "c": [{"t": "Str", "c": label}]}
+
 
 def render_diffs(key: str, value: Any, format: str, meta: Dict) -> Optional[List[Dict]]:
     if key != "Div":
         return None
     attrs, content = value
     classes = attrs[1]
+
+    from_pretty = _get_meta_str(meta, "diff-from-pretty")
+    to_pretty = _get_meta_str(meta, "diff-to-pretty")
+    has_label = from_pretty is not None and to_pretty is not None
+
     if "substitution" in classes:
-        return handle_substitution(content, format)
+        result = handle_substitution(content, format)
+        if has_label:
+            result = [_make_diff_label_para(from_pretty, to_pretty, "substitution")] + result
+        return result
     elif "insertion" in classes:
-        return handle_whole_block(content, format, "insertion")
+        result = handle_whole_block(content, format, "insertion")
+        if has_label:
+            result = [_make_diff_label_para(from_pretty, to_pretty, "insertion")] + result
+        return result
     elif "deletion" in classes:
-        return handle_whole_block(content, format, "deletion")
+        result = handle_whole_block(content, format, "deletion")
+        if has_label:
+            result = [_make_diff_label_para(from_pretty, to_pretty, "deletion")] + result
+        return result
     return None
 
 

--- a/doc_build/filters/filter_render_diff.py
+++ b/doc_build/filters/filter_render_diff.py
@@ -12,6 +12,7 @@ from diff_match_patch import diff_match_patch
 from pandocfilters import Strikeout, toJSONFilter
 
 from doc_build.diff_colors import (
+    DIFF_COMMENT_GRAY,
     DIFF_SECTION_DEL_PALE_RED,
     DIFF_SECTION_INS_PALE_GREEN,
     DIFF_WORD_DEL_RED,
@@ -58,6 +59,36 @@ _HTML_TEXT_DECORATION = {
     "insertion": "underline",
     "deletion": "line-through",
 }
+
+###############################################################################
+# Comment/label styling (gray italic small)
+###############################################################################
+
+_COMMENT_GRAY_HTML = f"#{DIFF_COMMENT_GRAY}"
+_COMMENT_GRAY_LATEX = DIFF_COMMENT_GRAY
+
+
+def _make_styled_comment_block(text: str, format: str) -> Dict:
+    """Return a block rendering text as a small gray italic diff comment.
+
+    HTML and LaTeX: full styling via per-format raw blocks.
+    GFM and other formats: italic only, applied at AST level via Emph.
+    """
+    if format == "html":
+        html = (
+            f'<p style="color: {_COMMENT_GRAY_HTML}; font-size: smaller;'
+            f' font-style: italic;">{text}</p>'
+        )
+        return {"t": "RawBlock", "c": ["html", html]}
+    elif format == "latex":
+        latex = (
+            f"\\noindent{{\\small\\textcolor[HTML]{{{_COMMENT_GRAY_LATEX}}}"
+            f"{{\\textit{{{text}}}}}}}"
+        )
+        return {"t": "RawBlock", "c": ["latex", latex]}
+    else:
+        # GFM and other formats: italics at AST level; gray/size not supported
+        return {"t": "Para", "c": [{"t": "Emph", "c": [Str(text)]}]}
 
 ###############################################################################
 # GFM diff styling
@@ -755,9 +786,9 @@ def _get_meta_str(meta: Dict, key: str) -> Optional[str]:
     return None
 
 
-def _make_diff_label_para(from_pretty: str, to_pretty: str, diff_type: str) -> Dict:
+def _make_diff_label_para(from_pretty: str, to_pretty: str, diff_type: str, format: str) -> Dict:
     label = f"Diff - from {from_pretty} to {to_pretty} - {_DIFF_TYPE_LABEL[diff_type]}"
-    return {"t": "Para", "c": [{"t": "Str", "c": label}]}
+    return _make_styled_comment_block(label, format)
 
 
 def render_diffs(key: str, value: Any, format: str, meta: Dict) -> Optional[List[Dict]]:
@@ -773,17 +804,17 @@ def render_diffs(key: str, value: Any, format: str, meta: Dict) -> Optional[List
     if "substitution" in classes:
         result = handle_substitution(content, format)
         if has_label:
-            result = [_make_diff_label_para(from_pretty, to_pretty, "substitution")] + result
+            result = [_make_diff_label_para(from_pretty, to_pretty, "substitution", format)] + result
         return result
     elif "insertion" in classes:
         result = handle_whole_block(content, format, "insertion")
         if has_label:
-            result = [_make_diff_label_para(from_pretty, to_pretty, "insertion")] + result
+            result = [_make_diff_label_para(from_pretty, to_pretty, "insertion", format)] + result
         return result
     elif "deletion" in classes:
         result = handle_whole_block(content, format, "deletion")
         if has_label:
-            result = [_make_diff_label_para(from_pretty, to_pretty, "deletion")] + result
+            result = [_make_diff_label_para(from_pretty, to_pretty, "deletion", format)] + result
         return result
     return None
 

--- a/doc_build/utils/git.py
+++ b/doc_build/utils/git.py
@@ -1,5 +1,6 @@
 """Utility functions for querying git metadata."""
 
+import collections.abc
 import contextlib
 import re
 import subprocess
@@ -8,13 +9,186 @@ from collections.abc import Generator
 from pathlib import Path
 from typing import Optional
 
+_HEX_HASH_PATTERN = re.compile(r"^[0-9a-f]+$", re.IGNORECASE)
 _SEMVER_TAG_PATTERN = re.compile(r"^v\d+\.\d+\.\d+$")
+
+
+def get_tag_timestamps(
+    repo_root: Path,
+    tags: str | collections.abc.Iterable[str] | None = None,
+) -> dict[str, int]:
+    """Return a {tag_name: unix_timestamp} dict for tags in the repo.
+
+    tags: a single tag name, an iterable of tag names, or None to fetch all tags.
+    """
+    if tags is None:
+        refs = ["refs/tags/"]
+    elif isinstance(tags, str):
+        refs = [f"refs/tags/{tags}"]
+    else:
+        refs = [f"refs/tags/{t}" for t in tags]
+        if not refs:
+            return {}
+    timestamps_output = (
+        subprocess.check_output(
+            ["git", "for-each-ref", "--format=%(creatordate:unix) %(refname:short)"] + refs,
+            cwd=repo_root,
+        )
+        .decode("utf-8")
+        .strip()
+    )
+    tag_ts: dict[str, int] = {}
+    for line in timestamps_output.splitlines():
+        parts = line.split(" ", 1)
+        if len(parts) == 2:
+            try:
+                tag_ts[parts[1]] = int(parts[0])
+            except ValueError:
+                pass
+    return tag_ts
+
+
+def tag_sort_key(
+    tag: str,
+    *,
+    tag_timestamp: dict[str, int] | str | None = None,
+    repo_root: Path | None = None,
+) -> tuple:
+    """Return a sort key for a tag.
+
+    Sorts semver tags first (0), then by timestamp ascending (older first),
+    then by length, then alphabetically.
+
+    tag_timestamp: a dict mapping tag names to unix timestamps, a single unix
+                   timestamp as a str, or None. If None and repo_root is
+                   provided, the timestamp is looked up automatically via
+                   get_tag_timestamps. If None and no repo_root, raises
+                   ValueError. Raises KeyError if a dict is provided but does
+                   not contain the tag. Raises ValueError if auto-lookup via
+                   repo_root finds no timestamp for the tag.
+    """
+    if isinstance(tag_timestamp, dict):
+        if tag not in tag_timestamp:
+            raise KeyError(f"tag {tag!r} not found in tag_timestamp dict")
+        ts = tag_timestamp[tag]
+    elif isinstance(tag_timestamp, str):
+        ts = int(tag_timestamp)
+    elif repo_root is not None:
+        result = get_tag_timestamps(repo_root, tag)
+        if tag not in result:
+            raise ValueError(f"no timestamp found for tag {tag!r} in repo {repo_root}")
+        ts = result[tag]
+    else:
+        raise ValueError(
+            f"cannot determine timestamp for tag {tag!r}: "
+            "provide tag_timestamp or repo_root"
+        )
+    is_semver = 0 if _SEMVER_TAG_PATTERN.match(tag) else 1
+    return (is_semver, ts, len(tag), tag)
+
+
+def sort_tags(tags: list[str], repo_root: Path) -> list[str]:
+    """Return tags sorted by tag_sort_key.
+
+    Fetches tag timestamps from git for-each-ref, then sorts.
+    """
+    tag_ts = get_tag_timestamps(repo_root)
+    return sorted(tags, key=lambda t: tag_sort_key(t, tag_timestamp=tag_ts))
+
+
+def _remote_tier(branch: str) -> int:
+    """Return a sort tier for a branch based on its remote.
+
+    origin remote = 0, other remotes = 1, local = 2.
+    """
+    if branch.startswith("remotes/origin/"):
+        return 0
+    if branch.startswith("remotes/"):
+        return 1
+    return 2
+
+
+def _display_name(branch: str) -> str:
+    """Return a human-readable display name for a branch ref."""
+    if branch.startswith("remotes/"):
+        parts = branch.split("/", 2)
+        return parts[1] + "/" + parts[2] if len(parts) == 3 else branch
+    return branch
+
+
+def branch_sort_key(branch: str) -> tuple:
+    """Return a sort key for a branch.
+
+    Sorts by remote tier (origin=0, other remotes=1, local=2), then by
+    display name length, then alphabetically.
+    """
+    name = _display_name(branch)
+    return (_remote_tier(branch), len(name), name)
+
+
+def sort_branches(branches: list[str]) -> list[str]:
+    """Return branches sorted by branch_sort_key."""
+    return sorted(branches, key=branch_sort_key)
+
+
+def get_ref_symbolic_name(ref: str, repo_root: Path) -> Optional[str]:
+    """Return a symbolic name for ref, or None if ref is a bare hash.
+
+    If ref is not a hex string, return it directly.  Otherwise, look for
+    tags pointing exactly to that commit (preferring semver, then older,
+    then shorter, then alphabetical), then branches (preferring origin
+    remote, then other remotes, then local; shorter/alphabetical within
+    each tier).  Returns None if nothing is found.
+    """
+    if not _HEX_HASH_PATTERN.match(ref):
+        return ref
+
+    full_hash = (
+        subprocess.check_output(["git", "rev-parse", ref], cwd=repo_root)
+        .decode("utf-8")
+        .strip()
+    )
+
+    tags_output = (
+        subprocess.check_output(["git", "tag", "--points-at", full_hash], cwd=repo_root)
+        .decode("utf-8")
+        .strip()
+    )
+    if tags_output:
+        tags = tags_output.splitlines()
+        return sort_tags(tags, repo_root)[0]
+
+    branches_output = (
+        subprocess.check_output(
+            ["git", "branch", "-a", "--points-at", full_hash], cwd=repo_root
+        )
+        .decode("utf-8")
+        .strip()
+    )
+    if branches_output:
+        branches = [b.strip().lstrip("* ") for b in branches_output.splitlines()]
+        return _display_name(sort_branches(branches)[0])
+
+    return None
 
 
 def commit_hash(ref: str, repo_root: Path, *, short: bool = False) -> str:
     """Resolve a git ref (branch, tag, hash) to a commit hash in the repo."""
     args = ["git", "rev-parse", "--short", ref] if short else ["git", "rev-parse", ref]
     return subprocess.check_output(args, cwd=repo_root).decode("utf-8").strip()
+
+
+def get_ref_pretty_str(ref: str, repo_root: Path) -> str:
+    """Return '<symbolic-name> (<short-hash>)' or '(<short-hash>)' for ref."""
+    short_hash = (
+        subprocess.check_output(["git", "rev-parse", "--short", ref], cwd=repo_root)
+        .decode("utf-8")
+        .strip()
+    )
+    symbolic = get_ref_symbolic_name(ref, repo_root)
+    if symbolic:
+        return f"{symbolic} ({short_hash})"
+    return f"({short_hash})"
 
 
 def get_latest_tag(


### PR DESCRIPTION
Each insertion, deletion, and substitution block is prefixed with a
plain-text Para: 'Diff - from <from-pretty> to <to-pretty> - Add/Remove/Substitution'.
The pretty string resolves the original ref to a symbolic name (non-hex
refs used as-is; hex hashes resolved via tags then branches) plus the
7-char short hash. Pretty strings are passed to the render filter via
pandoc -M metadata.

diff - style searchable labels as small, gray italic

- Add DIFF_COMMENT_GRAY (#808080) to diff_colors.py
- _make_diff_label_para now takes format and emits per-format styled blocks:
    - HTML: RawBlock <p style="color/font-size/font-style">
    - LaTeX: RawBlock \noindent{\small\textcolor[HTML]{...}{\textit{...}}}
    - GFM/other: Para with Emph (italics at AST level; gray/size not supported)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

